### PR TITLE
Add grammar support for “”” pystrings

### DIFF
--- a/grammars/feature.cson
+++ b/grammars/feature.cson
@@ -37,6 +37,22 @@
     'name': 'string.other.feature'
   }
   {
+    'begin': '^\\s*\\\"\"\"'
+    'end': '\\\"\"\"$'
+    'name': 'string.other.feature'
+    'patterns': [
+        {
+            'include': 'source.html'
+        },
+        {
+            'include': 'source.json'
+        },
+        {
+            'include': 'source.xml'
+        }
+    ] 
+  }
+  {
     'begin': '"'
     'end': '"'
     'name': 'string.interpolated.feature'


### PR DESCRIPTION
See http://behat.org/en/latest/user_guide/writing_scenarios.html#pystrings

Using pystrings would usually work fine when not using characters like "@". Using those characters for example to write an email address would mess up the whole grammar.

I have added support for html, json and xml to be used in the pystrings but normal text works too.